### PR TITLE
Feature: Title enforcement for first node in editor.

### DIFF
--- a/components/Editor/Editor.tsx
+++ b/components/Editor/Editor.tsx
@@ -19,8 +19,10 @@ const Editor = ({ state, manager }: any) => {
   const handleSave = () => {
     const collectionRef = collection(db, 'notes');
     const content = getJSON(state);
+    const title = content.content[0].text;
     const dbEntry = {
       created_at: Timestamp.fromDate(new Date(Date.now())),
+      title,
       content,
       user: user.uid,
     };

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,7 +21,7 @@ import { HamburgerIcon, CloseIcon, AddIcon } from '@chakra-ui/icons';
 import { ReactNode } from 'react';
 import NextLink from 'next/link';
 import { useAuth } from '../contexts/AuthContext';
-import DarkModeSwitch from '../components/DarkModeSwitch';
+import DarkModeSwitch from './DarkModeSwitch';
 
 const Links = [
   { name: 'Home', url: '/' },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,7 +15,7 @@ function MyApp({ Component, pageProps }) {
         <Component {...pageProps} />
       </AuthProvider>
     </ChakraProvider>
-    );
+  );
 }
 
 export default MyApp;

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -2,7 +2,7 @@ import 'remirror/styles/all.css';
 
 import { Flex, Grid, GridItem } from '@chakra-ui/react';
 import { ReactSsrExtension } from '@remirror/extension-react-ssr';
-import { Remirror, ThemeProvider, useRemirror } from '@remirror/react';
+import { Remirror, useRemirror } from '@remirror/react';
 import React, { useMemo } from 'react';
 import {
   BlockquoteExtension,
@@ -19,8 +19,8 @@ import {
 } from 'remirror/extensions';
 
 import Editor from '../components/Editor/Editor';
-import NotesList from '../components/NoteList';
 import { HyperlinkExtension } from '../components/Editor/extensions';
+import NotesList from '../components/NoteList';
 
 const Create = () => {
   const { manager, state, setState } = useRemirror({
@@ -39,6 +39,8 @@ const Create = () => {
       new UnderlineExtension(),
       new ReactSsrExtension({}),
     ],
+    content: '<h1>Untitled...</h1>',
+    stringHandler: 'html',
   });
 
   return (
@@ -49,7 +51,7 @@ const Create = () => {
         </GridItem>
         <GridItem>
           <div className="remirror-theme">
-            <Remirror manager={manager} state={state} onChange={(p) => setState(p.state)}>
+            <Remirror manager={manager} state={state} onChange={({ state }) => setState(state)}>
               <Editor state={state} manager={manager} />
             </Remirror>
           </div>


### PR DESCRIPTION
~Note: this PR doesn't change the saving function; that will come in another PR.~

- Save function now adds a `title` field to the collection entry.
- Note Editor automatically applies a H1 style to the first node – if there is no content in the first node, applies a default title of `Untitled`